### PR TITLE
Adding example SARS-CoV-2 sample xml to covid submission doc

### DIFF
--- a/help_and_guides/sars-cov-2-submissions.rst
+++ b/help_and_guides/sars-cov-2-submissions.rst
@@ -87,6 +87,7 @@ Please use the organism name â€œSevere acute respiratory syndrome coronavirus 2â
    </SAMPLE>
  </SAMPLE_SET>
 
+
 Metagenomic Samples
 -------------------
 Data submissions which include metagenomic samples, should be registered with a relevant metagenome taxonomy - visit our FAQ on `Tips for Taxonomy <https://ena-docs.readthedocs.io/en/latest/faq/taxonomy.html#environmental-biome-level-taxonomy>`_ for more information. A few examples include human lung metagenome - `433733 <https://www.ebi.ac.uk/ena/browser/view/Taxon:433733>`_, human saliva metagenome - `1679718 <https://www.ebi.ac.uk/ena/browser/view/Taxon:1679718>`_, human tracheal metagenome - `1712573 <https://www.ebi.ac.uk/ena/browser/view/Taxon:1712573>`_ or human metagenome - `646099 <https://www.ebi.ac.uk/ena/browser/view/Taxon:646099>`_, among many others. Please contact us if you require help with this.

--- a/help_and_guides/sars-cov-2-submissions.rst
+++ b/help_and_guides/sars-cov-2-submissions.rst
@@ -27,7 +27,7 @@ Please use the organism name â€œSevere acute respiratory syndrome coronavirus 2â
 .. code-block:: xml
 
  <SAMPLE_SET>
-   <SAMPLE alias="Test SARS-CoV-2 sample" center_name="EBI">
+   <SAMPLE alias="Test SARS-CoV-2 sample 1" center_name="EBI">
     <TITLE>Test SARS-CoV-2 Sample 1 Title</TITLE>
     <SAMPLE_NAME>
       <TAXON_ID>2697049</TAXON_ID>
@@ -82,10 +82,6 @@ Please use the organism name â€œSevere acute respiratory syndrome coronavirus 2â
       <SAMPLE_ATTRIBUTE>
         <TAG>ENA-CHECKLIST</TAG>
         <VALUE>ERC000033</VALUE>
-      </SAMPLE_ATTRIBUTE>
-      <SAMPLE_ATTRIBUTE>
-        <TAG>sample derived from</TAG>
-        <VALUE>SAMEA7000146</VALUE>
       </SAMPLE_ATTRIBUTE>
     </SAMPLE_ATTRIBUTES>
    </SAMPLE>

--- a/help_and_guides/sars-cov-2-submissions.rst
+++ b/help_and_guides/sars-cov-2-submissions.rst
@@ -22,9 +22,7 @@ The most appropriate checklist for SARS-CoV-2 viral submissions is the “ENA vi
 
 Please use the organism name “Severe acute respiratory syndrome coronavirus 2” and taxonomic ID 2697049. It is recommended, as a minimum, that collection date and geographic location (e.g. country) are specified and sample capture status field is provided a value of ‘active surveillance in response to outbreak’.
  
-Please see below for a template SARS-CoV-2 viral sample xml for programmatic submission to the ENA:
-
-**sample.xml:**
+**Please see below for a template SARS-CoV-2 viral sample xml for programmatic submission to the ENA:**
 
 .. code-block:: xml
 

--- a/help_and_guides/sars-cov-2-submissions.rst
+++ b/help_and_guides/sars-cov-2-submissions.rst
@@ -21,6 +21,72 @@ Viral Samples
 The most appropriate checklist for SARS-CoV-2 viral submissions is the “ENA virus pathogen reporting standard checklist” - `ERC000033 <https://www.ebi.ac.uk/ena/browser/view/ERC000033>`_. This presents 9 mandatory, 15 recommended and 11 optional fields (along with any additional user-defined fields).
 
 Please use the organism name “Severe acute respiratory syndrome coronavirus 2” and taxonomic ID 2697049. It is recommended, as a minimum, that collection date and geographic location (e.g. country) are specified and sample capture status field is provided a value of ‘active surveillance in response to outbreak’.
+ 
+Please see below for a template SARS-CoV-2 viral sample xml for programmatic submission to the ENA:
+
+```xml    
+<?xml version="1.0" encoding="UTF-8"?>
+<SAMPLE_SET>
+  <SAMPLE alias="Test SARS-CoV-2 sample 2" center_name="EBI">
+    <TITLE>Test SARS-CoV-2 Sample 2 Title</TITLE>
+    <SAMPLE_NAME>
+      <TAXON_ID>2697049</TAXON_ID>
+      <SCIENTIFIC_NAME>Severe acute respiratory syndrome coronavirus 2</SCIENTIFIC_NAME>
+      <COMMON_NAME>SARS-CoV-2</COMMON_NAME>
+    </SAMPLE_NAME>
+    <SAMPLE_ATTRIBUTES>
+      <SAMPLE_ATTRIBUTE>
+        <TAG>geographic location (country and/or sea)</TAG>
+        <VALUE>United Kingdom</VALUE>
+      </SAMPLE_ATTRIBUTE>
+	  <SAMPLE_ATTRIBUTE>
+        <TAG>collection date</TAG>
+        <VALUE>2020-04-26</VALUE>
+      </SAMPLE_ATTRIBUTE>
+      <SAMPLE_ATTRIBUTE>
+        <TAG>host common name</TAG>
+        <VALUE>human</VALUE>
+     </SAMPLE_ATTRIBUTE>
+      <SAMPLE_ATTRIBUTE>
+        <TAG>host subject id</TAG>
+        <VALUE>1</VALUE>
+	  </SAMPLE_ATTRIBUTE>
+	  <SAMPLE_ATTRIBUTE>
+        <TAG>host health state</TAG>
+        <VALUE>diseased</VALUE>
+	  </SAMPLE_ATTRIBUTE>
+	  <SAMPLE_ATTRIBUTE>
+        <TAG>host sex</TAG>
+        <VALUE>female</VALUE>
+	  </SAMPLE_ATTRIBUTE>
+	  <SAMPLE_ATTRIBUTE>
+        <TAG>host scientific name</TAG>
+        <VALUE>homo sapien</VALUE>
+	  </SAMPLE_ATTRIBUTE>
+	  <SAMPLE_ATTRIBUTE>
+        <TAG>collector name</TAG>
+        <VALUE>Jane Smith</VALUE>
+	  </SAMPLE_ATTRIBUTE>
+	  <SAMPLE_ATTRIBUTE>
+        <TAG>collecting institution</TAG>
+        <VALUE>EMBL-EBI, Wellcome Genome Campus Cambridge CB10 1SD</VALUE>
+	  </SAMPLE_ATTRIBUTE>
+	  <SAMPLE_ATTRIBUTE>
+        <TAG>isolate</TAG>
+        <VALUE>hCoV-19/UK/Bristol/2020</VALUE>
+	  </SAMPLE_ATTRIBUTE>
+	  <SAMPLE_ATTRIBUTE>
+        <TAG>sample capture status</TAG>
+        <VALUE>active surveillance in response to outbreak</VALUE>
+	  </SAMPLE_ATTRIBUTE>
+	  <SAMPLE_ATTRIBUTE>
+        <TAG>ENA-CHECKLIST</TAG>
+        <VALUE>ERC000033</VALUE>
+      </SAMPLE_ATTRIBUTE>
+    </SAMPLE_ATTRIBUTES>
+	</SAMPLE>
+</SAMPLE_SET>    
+```
 
 Metagenomic Samples
 -------------------

--- a/help_and_guides/sars-cov-2-submissions.rst
+++ b/help_and_guides/sars-cov-2-submissions.rst
@@ -24,11 +24,13 @@ Please use the organism name â€œSevere acute respiratory syndrome coronavirus 2â
  
 Please see below for a template SARS-CoV-2 viral sample xml for programmatic submission to the ENA:
 
-```xml    
-<?xml version="1.0" encoding="UTF-8"?>
-<SAMPLE_SET>
-  <SAMPLE alias="Test SARS-CoV-2 sample 2" center_name="EBI">
-    <TITLE>Test SARS-CoV-2 Sample 2 Title</TITLE>
+**sample.xml:**
+
+.. code-block:: xml
+
+ <SAMPLE_SET>
+   <SAMPLE alias="Test SARS-CoV-2 sample" center_name="EBI">
+    <TITLE>Test SARS-CoV-2 Sample 1 Title</TITLE>
     <SAMPLE_NAME>
       <TAXON_ID>2697049</TAXON_ID>
       <SCIENTIFIC_NAME>Severe acute respiratory syndrome coronavirus 2</SCIENTIFIC_NAME>
@@ -39,54 +41,57 @@ Please see below for a template SARS-CoV-2 viral sample xml for programmatic sub
         <TAG>geographic location (country and/or sea)</TAG>
         <VALUE>United Kingdom</VALUE>
       </SAMPLE_ATTRIBUTE>
-	  <SAMPLE_ATTRIBUTE>
+      <SAMPLE_ATTRIBUTE>
         <TAG>collection date</TAG>
         <VALUE>2020-04-26</VALUE>
       </SAMPLE_ATTRIBUTE>
       <SAMPLE_ATTRIBUTE>
         <TAG>host common name</TAG>
         <VALUE>human</VALUE>
-     </SAMPLE_ATTRIBUTE>
+      </SAMPLE_ATTRIBUTE>
       <SAMPLE_ATTRIBUTE>
         <TAG>host subject id</TAG>
         <VALUE>1</VALUE>
-	  </SAMPLE_ATTRIBUTE>
-	  <SAMPLE_ATTRIBUTE>
+      </SAMPLE_ATTRIBUTE>
+      <SAMPLE_ATTRIBUTE>
         <TAG>host health state</TAG>
         <VALUE>diseased</VALUE>
-	  </SAMPLE_ATTRIBUTE>
-	  <SAMPLE_ATTRIBUTE>
+      </SAMPLE_ATTRIBUTE>
+      <SAMPLE_ATTRIBUTE>
         <TAG>host sex</TAG>
         <VALUE>female</VALUE>
-	  </SAMPLE_ATTRIBUTE>
-	  <SAMPLE_ATTRIBUTE>
+      </SAMPLE_ATTRIBUTE>
+      <SAMPLE_ATTRIBUTE>
         <TAG>host scientific name</TAG>
         <VALUE>homo sapien</VALUE>
-	  </SAMPLE_ATTRIBUTE>
-	  <SAMPLE_ATTRIBUTE>
+      </SAMPLE_ATTRIBUTE>
+      <SAMPLE_ATTRIBUTE>
         <TAG>collector name</TAG>
         <VALUE>Jane Smith</VALUE>
-	  </SAMPLE_ATTRIBUTE>
-	  <SAMPLE_ATTRIBUTE>
+      </SAMPLE_ATTRIBUTE>
+      <SAMPLE_ATTRIBUTE>
         <TAG>collecting institution</TAG>
         <VALUE>EMBL-EBI, Wellcome Genome Campus Cambridge CB10 1SD</VALUE>
-	  </SAMPLE_ATTRIBUTE>
-	  <SAMPLE_ATTRIBUTE>
+      </SAMPLE_ATTRIBUTE> 
+      <SAMPLE_ATTRIBUTE>
         <TAG>isolate</TAG>
         <VALUE>hCoV-19/UK/Bristol/2020</VALUE>
-	  </SAMPLE_ATTRIBUTE>
-	  <SAMPLE_ATTRIBUTE>
+      </SAMPLE_ATTRIBUTE>
+      <SAMPLE_ATTRIBUTE>
         <TAG>sample capture status</TAG>
         <VALUE>active surveillance in response to outbreak</VALUE>
-	  </SAMPLE_ATTRIBUTE>
-	  <SAMPLE_ATTRIBUTE>
+      </SAMPLE_ATTRIBUTE>
+      <SAMPLE_ATTRIBUTE>
         <TAG>ENA-CHECKLIST</TAG>
         <VALUE>ERC000033</VALUE>
       </SAMPLE_ATTRIBUTE>
+      <SAMPLE_ATTRIBUTE>
+        <TAG>sample derived from</TAG>
+        <VALUE>SAMEA7000146</VALUE>
+      </SAMPLE_ATTRIBUTE>
     </SAMPLE_ATTRIBUTES>
-	</SAMPLE>
-</SAMPLE_SET>    
-```
+   </SAMPLE>
+ </SAMPLE_SET>
 
 Metagenomic Samples
 -------------------


### PR DESCRIPTION
To encourage the inclusion of correct and maximal SARS-CoV-2 metadata,  I have added a template SARS-CoV-2 sample xml containing mandatory and the recommended fields of 'collection date' and 'sample capture status' from ERC000033.